### PR TITLE
Added platform argument for distribute to allow distributing Apple TV apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ $ ipa distribute:itunesconnect -a me@email.com -p myitunesconnectpassword -i app
 > The `-i` (or `--apple-id`) flag is "An automatically generated ID assigned to your app". It can be found via iTunes Connect by navigating to:
 > * My Apps -> [App Name] -> More -> About This App -> Apple ID
 >
-> If you are planning on distributing your AppleTV app, you simply need to add `--platform appletvos`.
+> If you are planning on distributing your Apple TV app, you simply need to add `--platform appletvos`.
 >
 > For a fully hands-free upload, in a CI environment for example, ensure your iTunes Connect credentials are stored in your keychain, and that the keychain item has the Validation app in its 'Always allow access' list.  Running Shenzhen once with the `--save-keychain` flag, and clicking `Always Allow` on the prompt will set this up for you.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Shenzhen](https://raw.github.com/nomad/nomad.github.io/assets/shenzhen-banner.png)
 
-## This is a fork from [nomad shenzhen](https://github.com/nomad/shenzhen) which fixes issues with the Apple Watch.
+## This is a fork from [fastlane shenzhen](https://github.com/fastlane/shenzhen) which fixes issues with the Apple TV.
 
 Create `.ipa` files and distribute them from the command line, using any of the following methods:
 
@@ -167,6 +167,8 @@ $ ipa distribute:itunesconnect -a me@email.com -p myitunesconnectpassword -i app
 >
 > The `-i` (or `--apple-id`) flag is "An automatically generated ID assigned to your app". It can be found via iTunes Connect by navigating to:
 > * My Apps -> [App Name] -> More -> About This App -> Apple ID
+>
+> If you are planning on distributing your AppleTV app, you simply need to add `--platform appletvos`.
 >
 > For a fully hands-free upload, in a CI environment for example, ensure your iTunes Connect credentials are stored in your keychain, and that the keychain item has the Validation app in its 'Always allow access' list.  Running Shenzhen once with the `--save-keychain` flag, and clicking `Always Allow` on the prompt will set this up for you.
 


### PR DESCRIPTION
The current metadata template does not work for Apple TV.

You will most likely get an error saying that the provisioning profile used is not compatible with iOS apps. With this patch, you'd have to add "--platform appletvos" to your ipa distribute:itunesconnect command. If you don't supply this argument, it will revert to the old metadata xml file.
