### PR TITLE
Add aws-sdk 1.0 dependency on shenzhen.

### DIFF
--- a/shenzhen.gemspec
+++ b/shenzhen.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "faraday", "~> 0.9"
   s.add_dependency "faraday_middleware", "~> 0.9"
   s.add_dependency "dotenv", ">= 0.7"
+  s.add_dependency "aws-sdk", "~> 1.0"
   s.add_dependency "net-sftp", "~> 2.1.2"
   s.add_dependency "plist", "~> 3.1.0"
   s.add_dependency "rubyzip", "~> 1.1"


### PR DESCRIPTION
This is exactly what the official [shenzhen](https://github.com/nomad/shenzhen/blob/master/shenzhen.gemspec) gem is doing.

This will fix issue here: https://github.com/fastlane/fastlane/pull/810
