### PR TITLE
Update plist dependency

### DIFF
--- a/lib/shenzhen/commands/info.rb
+++ b/lib/shenzhen/commands/info.rb
@@ -44,7 +44,7 @@ command :info do |c|
         temp_provisioning_profile = ::File.new(::File.join(tempdir.path, provisioning_profile_entry.name))
         temp_app_directory = ::File.new(::File.join(tempdir.path, app_entry.name))
 
-        plist = Plist::parse_xml(`security cms -D -i #{temp_provisioning_profile.path}`)
+        plist = Plist::parse_xml(`security cms -D -i '#{temp_provisioning_profile.path}'`)
 
         codesign = `codesign -dv "#{temp_app_directory.path}" 2>&1`
         codesigned = /Signed Time/ === codesign

--- a/shenzhen.gemspec
+++ b/shenzhen.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "faraday_middleware", "~> 0.9"
   s.add_dependency "dotenv", ">= 0.7"
   s.add_dependency "net-sftp", "~> 2.1.2"
-  s.add_dependency "plist", "~> 3.1.0"
+  s.add_dependency "plist", ">= 3.1.0", "< 4.0.0"
   s.add_dependency "rubyzip", "~> 1.1"
   s.add_dependency "security", "~> 0.1.3"
 


### PR DESCRIPTION
This resolves the issue described in fastlane/fastlane#6917 by setting the plist gem version requirement to the same value as for the other fastlane tools.